### PR TITLE
Reintegrated my changes for >IP channel lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ source/ChanSort.opensdf
 /source/.vs/
 /source/packages/
 /source/ChanSort.Loader.PhilipsBin/DllClient.cs
+*.wsuo

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ source/ChanSort.opensdf
 /source/packages/
 /source/ChanSort.Loader.PhilipsBin/DllClient.cs
 *.wsuo
+/.vs

--- a/source/ChanSort.Api/Model/ChannelInfo.cs
+++ b/source/ChanSort.Api/Model/ChannelInfo.cs
@@ -61,6 +61,7 @@ namespace ChanSort.Api
     public int AudioPid { get; set; }
     public int OriginalNetworkId { get; set; }
     public int TransportStreamId { get; set; }
+    public int PhysicalChannel { get; set; }
     public string Provider { get; set; }
     public int SymbolRate { get; set; }
     public int ServiceType { get; set; }
@@ -107,12 +108,14 @@ namespace ChanSort.Api
     /// </summary>
     public string Debug { get; private set; }
 
-
-
+    /// <summary>
+    /// delivery number to seperate dvbc/dvbt/dvbs from cableip/antennaip/satip
+    /// </summary>
+    public int DeliveryType { get; set; }
 
     #region ctor()
 
-    public ChannelInfo()
+        public ChannelInfo()
     {
       this.OldProgramNr = -1;
       this.NewProgramNr = -1;

--- a/source/ChanSort.Api/Model/DataRoot.cs
+++ b/source/ChanSort.Api/Model/DataRoot.cs
@@ -96,7 +96,9 @@ namespace ChanSort.Api
 
         if ((searchMask & SignalSource.MaskAnalogDigital) != 0 && (listMask & SignalSource.MaskAnalogDigital & searchMask) == 0) // digital/analog
           continue;
-        if ((searchMask & SignalSource.MaskAntennaCableSat) != 0 && (listMask & SignalSource.MaskAntennaCableSat & searchMask) == 0) // air/cable/sat/ip
+        if ((searchMask & SignalSource.MaskAntennaCableSat) != 0 && (listMask & SignalSource.MaskAntennaCableSat & searchMask) == 0) // antenna/cable/sat
+          continue;
+        if ((searchMask & SignalSource.IP) != 0 && (listMask & SignalSource.IP & searchMask) == 0) // ANTENNA>IP/CABLE>IP/SAT>IP
           continue;
         if ((searchMask & SignalSource.MaskTvRadioData) != 0 && (listMask & SignalSource.MaskTvRadioData & searchMask) == 0) // tv/radio/data
           continue;

--- a/source/ChanSort.Api/Model/Enums.cs
+++ b/source/ChanSort.Api/Model/Enums.cs
@@ -30,10 +30,11 @@ namespace ChanSort.Api
     Cable = 32,
     // 0x0040 // 0000000001000000
     Sat = 64,
-    // 0x0080 // 0000000010000000
+    // 0x0078 // 0000000001111000
+    MaskAntennaCableSat = AVInput | Antenna | Cable | Sat,              // bit 3-6: AvInput/Antenna/Cable/Sat
+
+    // 0x0080 // 0000000010000000                                       // bit 7: ANTENNA>IP/CABLE>IP/SAT>IP
     IP = 128,
-    // 0x00F8 // 0000000011111000
-    MaskAntennaCableSat = AVInput | Antenna | Cable | Sat | IP,         // bit 3-7: AvInput/Antenna/Cable/Sat/IP
 
     // 0x0011 // 0000000000010001
     AnalogAntenna = Analog + Antenna,

--- a/source/ChanSort.Api/Model/Enums.cs
+++ b/source/ChanSort.Api/Model/Enums.cs
@@ -11,29 +11,90 @@ namespace ChanSort.Api
   [Flags]
   public enum SignalSource
   {
+    // 0x0000 // 0000000000000000
     Any = 0,
 
-    // bit 0-1: analog/digital
-    MaskAnalogDigital = 0x0003,
-    Analog = 0x0001,
-    Digital = 0x0002,
+    // 0x0001 // 0000000000000001
+    Analog = 1,
+    // 0x0002 // 0000000000000010
+    Digital = 2,
+    // 0x0003 // 0000000000000011
+    MaskAnalogDigital = Analog | Digital,                               // bit 0-1: analog/digital
 
-    // bit 3-7: AvInput/Antenna/Cable/Sat/IP
-    MaskAntennaCableSat = 0x00F8,
-    AvInput = 0x0008,
-    Antenna = 0x0010,
-    Cable = 0x0020,
-    Sat = 0x0040,
-    IP = 0x0080,
+    // 0x0008 // 0000000000001000
+    AVInput = 8,
+    AvInput = 8,
+    // 0x0010 // 0000000000010000
+    Antenna = 16,
+    // 0x0020 // 0000000000100000
+    Cable = 32,
+    // 0x0040 // 0000000001000000
+    Sat = 64,
+    // 0x0080 // 0000000010000000
+    IP = 128,
+    // 0x00F8 // 0000000011111000
+    MaskAntennaCableSat = AVInput | Antenna | Cable | Sat | IP,         // bit 3-7: AvInput/Antenna/Cable/Sat/IP
 
-    MaskAdInput = MaskAnalogDigital | MaskAntennaCableSat,
+    // 0x0011 // 0000000000010001
+    AnalogAntenna = Analog + Antenna,
+    AnalogT = Analog + Antenna,
+    // 0x0021 // 0000000000100001
+    AnalogCable = Analog + Cable,
+    AnalogC = Analog + Cable,
+    // 0x0031 // 0000000000110001
+    AnalogAntennaCable = Analog + Antenna + Cable,
+    AnalogCT = Analog + Cable + Antenna,
+    // 0x0041 // 0000000001000001
+    AnalogSat = Analog + Sat,
+    // 0x0012 // 0000000000010010
+    DVBT = Digital + Antenna,
+    DvbT = Digital + Antenna,
+    // 0x0022 // 0000000000100010
+    DVBC = Digital + Cable,
+    DvbC = Digital + Cable,
+    // 0x0032 // 0000000000110010
+    DVBTC = Digital + Antenna + Cable,
+    DvbCT = Digital + Cable + Antenna,
+    // 0x0042 // 0000000001000010
+    DVBS = Digital + Sat,
+    DvbS = Digital + Sat,
+    // 0x0072 // 0000000001110010
+    DVBAll = Digital + Antenna + Cable + Sat,
+    // 0x0092 // 0000000010010010
+    DVBIPAntenna = Digital + Antenna + IP,
+    // 0x00A2 // 0000000010100010
+    DVBIPCable = Digital + Cable + IP,
+    // 0x00C2 // 0000000011000010
+    DVBIPSat = Digital + Sat + IP,
+    SatIP = Digital + Sat + IP,
 
-    // bit 8-10: TV/Radio/Data
-    MaskTvRadioData = 0x0700,
-    Tv = 0x0100,
-    Radio = 0x0200,
-    Data = 0x0400,
-    TvAndData = Tv|Data,
+    // 0x00FB // 0000000011111011
+    AllAnalogDigitalInput = MaskAnalogDigital | MaskAntennaCableSat,
+    // 0x00FB // 0000000011111011
+    MaskAdInput = MaskAnalogDigital | MaskAntennaCableSat,              // bit 0-7: Combination of above
+
+    // 0x0100 // 0000000100000000
+    TV = 256,
+    Tv = 256,
+    // 0x0200 // 0000001000000000
+    Radio = 512,
+    // 0x0400 // 0000010000000000
+    Data = 1024,
+    // 0x0300 // 0000001100000000
+    TVAndRadio = TV | Radio,
+    // 0x0500 // 0000010100000000
+    TVAndData = TV | Data,
+    TvAndData = TV | Data,
+    // 0x0600 // 0000011000000000
+    RadioAndData = Radio | Data,
+    // 0x0700 // 0000011100000000
+    TVAndRadioAndData = TV | Radio | Data,
+    // 0x0700 // 0000011100000000
+    MaskTVRadioData = TV | Radio | Data,                                // bit 8-10: TV/Radio/Data
+    MaskTvRadioData = TV | Radio | Data,
+
+    // 0x07FB // 0000011111111011
+    All = MaskAnalogDigital | MaskAntennaCableSat | MaskTVRadioData,
 
     // bit 12-15: Preset list selector (AstraHD+, Freesat, TivuSat, CanalDigitalSat, ... for Samsung)
     MaskProvider = 0xF000,
@@ -54,15 +115,6 @@ namespace ChanSort.Api
     StandardCable = 0 << 12,
     CablePrime = 1 << 12,
 
-    AnalogC = Analog + Cable,
-    AnalogT = Analog + Antenna,
-    AnalogCT = Analog + Cable + Antenna,
-    DvbC = Digital + Cable,
-    DvbT = Digital + Antenna,
-    DvbCT = Digital + Cable + Antenna,
-    DvbS = Digital + Sat,
-    SatIP = Digital + IP, // must NOT add Sat
-
     CablePrimeD = Digital + Cable + CablePrime,
     HdPlusD = Digital + Sat + AstraHdPlus,
     FreesatD = Digital + Sat + Freesat,
@@ -70,8 +122,6 @@ namespace ChanSort.Api
     CanalDigitalSatD = Digital + Sat + CanalDigital,
     DigitalPlusD = Digital + Sat + DigitalPlus,
     CyfraPlusD = Digital + Sat + CyfraPlus,
-
-    All = MaskAnalogDigital | MaskAntennaCableSat | MaskTvRadioData
   }
   #endregion
 

--- a/source/ChanSort.Loader.Panasonic/DbChannel.cs
+++ b/source/ChanSort.Loader.Panasonic/DbChannel.cs
@@ -42,13 +42,13 @@ namespace ChanSort.Loader.Panasonic
       else if (ntype == 15)
       {
           if (DeliveryType == 15)
-              SignalSource |= SignalSource.DVBIPSat;
+              this.SignalSource |= SignalSource.DVBIPSat;
           //else if (this.DeliveryType == 0) // Currently no sample for AntennaIP found
-          //    SignalSource |= SignalSource.DVBIPAntenna;
-          else if (DeliveryType == 18) 
-              SignalSource |= SignalSource.DVBIPCable;
-          else 
-              SignalSource |= SignalSource.DVBIPSat;
+          //    this.SignalSource |= SignalSource.DVBIPAntenna;
+          else if (DeliveryType == 18)
+              this.SignalSource |= SignalSource.DVBIPCable;
+          else
+              this.SignalSource |= SignalSource.DVBIPSat;
       }
 
       byte[] buffer = new byte[1000];

--- a/source/ChanSort.Loader.Panasonic/DbChannel.cs
+++ b/source/ChanSort.Loader.Panasonic/DbChannel.cs
@@ -24,6 +24,7 @@ namespace ChanSort.Loader.Panasonic
       {
       }
       int ntype = r.GetInt32(field["ntype"]);
+      DeliveryType = r.GetInt32(field["delivery_type"]); 
       if (ntype == 1)
       {
         this.SignalSource |= SignalSource.DvbS;
@@ -39,7 +40,16 @@ namespace ChanSort.Loader.Panasonic
       else if (ntype == 14)
         this.SignalSource |= SignalSource.AnalogC | SignalSource.Tv;
       else if (ntype == 15)
-        this.SignalSource |= SignalSource.SatIP;
+      {
+          if (DeliveryType == 15)
+              SignalSource |= SignalSource.DVBIPSat;
+          //else if (this.DeliveryType == 0) // Currently no sample for AntennaIP found
+          //    SignalSource |= SignalSource.DVBIPAntenna;
+          else if (DeliveryType == 18) 
+              SignalSource |= SignalSource.DVBIPCable;
+          else 
+              SignalSource |= SignalSource.DVBIPSat;
+      }
 
       byte[] buffer = new byte[1000];
       int len = 0;
@@ -89,6 +99,11 @@ namespace ChanSort.Loader.Panasonic
     {
       this.FreqInMhz = r.IsDBNull(field["freq"]) ? 0 : (decimal)r.GetInt32(field["freq"]) / 1000;
       this.ChannelOrTransponder = Tools.GetAnalogChannelNumber((int)this.FreqInMhz);
+
+      this.PhysicalChannel = r.GetInt32(field["physical_ch"]);
+      this.OriginalNetworkId = r.GetInt32(field["onid"]);
+      this.TransportStreamId = r.GetInt32(field["tsid"]);
+      this.ServiceId = r.GetInt32(field["svcid"]);
     }
     #endregion
 
@@ -161,6 +176,7 @@ namespace ChanSort.Loader.Panasonic
         this.Source = (this.SignalSource & SignalSource.Antenna) != 0 ? "DVB-T" : "DVB-C";
       }
 
+      this.PhysicalChannel = r.GetInt32(field["physical_ch"]); 
       this.OriginalNetworkId = r.GetInt32(field["onid"]);
       this.TransportStreamId = r.GetInt32(field["tsid"]);
       this.ServiceId = r.GetInt32(field["sid"]);

--- a/source/ChanSort.Loader.Panasonic/SvlSerializer.cs
+++ b/source/ChanSort.Loader.Panasonic/SvlSerializer.cs
@@ -56,6 +56,8 @@ namespace ChanSort.Loader.Panasonic
       this.DataRoot.AddChannelList(this.dvbtChannels);
       this.DataRoot.AddChannelList(this.dvbcChannels);
       this.DataRoot.AddChannelList(this.dvbsChannels);
+      this.DataRoot.AddChannelList(this.antennaipChannels);
+      this.DataRoot.AddChannelList(this.cableipChannels);
       this.DataRoot.AddChannelList(this.satipChannels);
       this.DataRoot.AddChannelList(this.freesatChannels);
 

--- a/source/ChanSort.sln
+++ b/source/ChanSort.sln
@@ -152,7 +152,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HDD Hex Edit Neo", "HDD Hex
 		Information\FileStructures_for_HHD_Hex_Editor_Neo\tll-satellite.h = Information\FileStructures_for_HHD_Hex_Editor_Neo\tll-satellite.h
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChanSort.Loader.Medion", "ChanSort.Loader.Medion\ChanSort.Loader.Medion.csproj", "{171156F2-7000-4EFA-ADA1-61BA82F764DA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChanSort.Loader.Medion", "ChanSort.Loader.Medion\ChanSort.Loader.Medion.csproj", "{171156F2-7000-4EFA-ADA1-61BA82F764DA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -187,8 +187,8 @@ Global
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.All_Release|x86.Build.0 = Release|x86
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|x86.ActiveCfg = Debug|x86
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|x86.Build.0 = Debug|x86
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -216,8 +216,8 @@ Global
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.All_Release|x86.Build.0 = Release|x86
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|x86.ActiveCfg = Debug|x86
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|x86.Build.0 = Debug|x86
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -246,8 +246,8 @@ Global
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.All_Release|x86.Build.0 = Release|x86
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|x86.ActiveCfg = Debug|x86
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|x86.Build.0 = Debug|x86
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -276,8 +276,8 @@ Global
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.All_Release|x86.Build.0 = Release|x86
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|x86.ActiveCfg = Debug|x86
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|x86.Build.0 = Debug|x86
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -306,8 +306,8 @@ Global
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.All_Release|x86.Build.0 = Release|x86
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|x86.ActiveCfg = Debug|x86
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|x86.Build.0 = Debug|x86
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -336,8 +336,8 @@ Global
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.All_Release|x86.Build.0 = Release|x86
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|x86.ActiveCfg = Debug|x86
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|x86.Build.0 = Debug|x86
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -366,8 +366,8 @@ Global
 		{68DA8072-3A29-4076-9F64-D66F38349585}.All_Release|x86.Build.0 = Release|x86
 		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|x86.ActiveCfg = Debug|x86
 		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|x86.Build.0 = Debug|x86
 		{68DA8072-3A29-4076-9F64-D66F38349585}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -396,8 +396,8 @@ Global
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.All_Release|x86.Build.0 = Release|x86
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|x86.ActiveCfg = Debug|x86
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|x86.Build.0 = Debug|x86
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -426,8 +426,8 @@ Global
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.All_Release|x86.Build.0 = Release|x86
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|x86.ActiveCfg = Debug|x86
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|x86.Build.0 = Debug|x86
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -456,8 +456,8 @@ Global
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.All_Release|x86.Build.0 = Release|x86
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|x86.ActiveCfg = Debug|x86
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|x86.Build.0 = Debug|x86
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -486,8 +486,8 @@ Global
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.All_Release|x86.Build.0 = Release|x86
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|x86.ActiveCfg = Debug|x86
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|x86.Build.0 = Debug|x86
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -516,8 +516,8 @@ Global
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.All_Release|x86.Build.0 = Release|x86
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|x86.ActiveCfg = Debug|x86
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|x86.Build.0 = Debug|x86
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -546,8 +546,8 @@ Global
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.All_Release|x86.Build.0 = Release|x86
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|x86.ActiveCfg = Debug|x86
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|x86.Build.0 = Debug|x86
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -576,8 +576,8 @@ Global
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.All_Release|x86.Build.0 = Release|x86
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|x86.ActiveCfg = Debug|x86
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|x86.Build.0 = Debug|x86
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -606,8 +606,8 @@ Global
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.All_Release|x86.Build.0 = Release|x86
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|x86.ActiveCfg = Debug|x86
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|x86.Build.0 = Debug|x86
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -636,8 +636,8 @@ Global
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.All_Release|x86.Build.0 = Release|x86
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|x86.ActiveCfg = Debug|x86
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|x86.Build.0 = Debug|x86
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -666,8 +666,8 @@ Global
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.All_Release|x86.Build.0 = Release|x86
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|x86.ActiveCfg = Debug|x86
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|x86.Build.0 = Debug|x86
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -696,8 +696,8 @@ Global
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.All_Release|x86.Build.0 = Release|x86
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|x86.ActiveCfg = Debug|x86
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|x86.Build.0 = Debug|x86
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -726,8 +726,8 @@ Global
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.All_Release|x86.Build.0 = Release|x86
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|x86.ActiveCfg = Debug|x86
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|x86.Build.0 = Debug|x86
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -756,8 +756,8 @@ Global
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.All_Release|x86.Build.0 = Release|x86
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|x86.ActiveCfg = Debug|x86
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|x86.Build.0 = Debug|x86
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -786,8 +786,8 @@ Global
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.All_Release|x86.Build.0 = Release|x86
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|x86.ActiveCfg = Debug|x86
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|x86.Build.0 = Debug|x86
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -816,8 +816,8 @@ Global
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.All_Release|x86.Build.0 = Release|x86
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|x86.ActiveCfg = Debug|x86
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|x86.Build.0 = Debug|x86
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -846,8 +846,8 @@ Global
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.All_Release|x86.Build.0 = Release|Any CPU
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|x86.ActiveCfg = Debug|x86
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|x86.Build.0 = Debug|x86
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -876,8 +876,8 @@ Global
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.All_Release|x86.Build.0 = Release|Any CPU
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|x86.ActiveCfg = Debug|x86
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|x86.Build.0 = Debug|x86
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -906,8 +906,8 @@ Global
 		{052692BF-D782-4888-B34D-89D6B1379340}.All_Release|x86.Build.0 = Release|Any CPU
 		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|x86.ActiveCfg = Debug|x86
 		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|x86.Build.0 = Debug|x86
 		{052692BF-D782-4888-B34D-89D6B1379340}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -936,8 +936,8 @@ Global
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.All_Release|x86.Build.0 = Release|Any CPU
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|x86.ActiveCfg = Debug|x86
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|x86.Build.0 = Debug|x86
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -966,8 +966,8 @@ Global
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.All_Release|x86.Build.0 = Release|Any CPU
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|x86.ActiveCfg = Debug|x86
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|x86.Build.0 = Debug|x86
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -996,8 +996,8 @@ Global
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.All_Release|x86.Build.0 = Release|Any CPU
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|x86.ActiveCfg = Debug|x86
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|x86.Build.0 = Debug|x86
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -1026,8 +1026,8 @@ Global
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.All_Release|x86.Build.0 = Release|Any CPU
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|x86.ActiveCfg = Debug|x86
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|x86.Build.0 = Debug|x86
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -1056,8 +1056,8 @@ Global
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.All_Release|x86.Build.0 = Release|Any CPU
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|x86.ActiveCfg = Debug|x86
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|x86.Build.0 = Debug|x86
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -1086,8 +1086,8 @@ Global
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.All_Release|x86.Build.0 = Release|Any CPU
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|x86.ActiveCfg = Debug|x86
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|x86.Build.0 = Debug|x86
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/source/ChanSort.sln
+++ b/source/ChanSort.sln
@@ -152,7 +152,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HDD Hex Edit Neo", "HDD Hex
 		Information\FileStructures_for_HHD_Hex_Editor_Neo\tll-satellite.h = Information\FileStructures_for_HHD_Hex_Editor_Neo\tll-satellite.h
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChanSort.Loader.Medion", "ChanSort.Loader.Medion\ChanSort.Loader.Medion.csproj", "{171156F2-7000-4EFA-ADA1-61BA82F764DA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChanSort.Loader.Medion", "ChanSort.Loader.Medion\ChanSort.Loader.Medion.csproj", "{171156F2-7000-4EFA-ADA1-61BA82F764DA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -187,8 +187,8 @@ Global
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.All_Release|x86.Build.0 = Release|x86
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|x86.ActiveCfg = Debug|x86
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.Debug|x86.Build.0 = Debug|x86
 		{5FAFDABC-A52F-498C-BD2F-AFFC4119797A}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -216,8 +216,8 @@ Global
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.All_Release|x86.Build.0 = Release|x86
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|x86.ActiveCfg = Debug|x86
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.Debug|x86.Build.0 = Debug|x86
 		{DCCFFA08-472B-4D17-BB90-8F513FC01392}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -246,8 +246,8 @@ Global
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.All_Release|x86.Build.0 = Release|x86
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|x86.ActiveCfg = Debug|x86
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.Debug|x86.Build.0 = Debug|x86
 		{E972D8A1-2F5F-421C-AC91-CFF45E5191BE}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -276,8 +276,8 @@ Global
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.All_Release|x86.Build.0 = Release|x86
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|x86.ActiveCfg = Debug|x86
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.Debug|x86.Build.0 = Debug|x86
 		{68CFCB2F-B52A-43A1-AA5C-5D64A1D655D2}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -306,8 +306,8 @@ Global
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.All_Release|x86.Build.0 = Release|x86
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|x86.ActiveCfg = Debug|x86
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.Debug|x86.Build.0 = Debug|x86
 		{A1C9A98D-368A-44E8-9B7F-7EACA46C9EC5}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -336,8 +336,8 @@ Global
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.All_Release|x86.Build.0 = Release|x86
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|x86.ActiveCfg = Debug|x86
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.Debug|x86.Build.0 = Debug|x86
 		{F6F02792-07F1-48D5-9AF3-F945CA5E3931}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -366,8 +366,8 @@ Global
 		{68DA8072-3A29-4076-9F64-D66F38349585}.All_Release|x86.Build.0 = Release|x86
 		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|x86.ActiveCfg = Debug|x86
 		{68DA8072-3A29-4076-9F64-D66F38349585}.Debug|x86.Build.0 = Debug|x86
 		{68DA8072-3A29-4076-9F64-D66F38349585}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -396,8 +396,8 @@ Global
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.All_Release|x86.Build.0 = Release|x86
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|x86.ActiveCfg = Debug|x86
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.Debug|x86.Build.0 = Debug|x86
 		{F943DBFE-D3C3-4885-A38B-375148012FEC}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -426,8 +426,8 @@ Global
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.All_Release|x86.Build.0 = Release|x86
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|x86.ActiveCfg = Debug|x86
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.Debug|x86.Build.0 = Debug|x86
 		{74A18C6F-09FF-413E-90D9-827066FA5B36}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -456,8 +456,8 @@ Global
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.All_Release|x86.Build.0 = Release|x86
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|x86.ActiveCfg = Debug|x86
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.Debug|x86.Build.0 = Debug|x86
 		{D093E7EE-D3AD-4E7B-AF82-C6918CA017FB}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -486,8 +486,8 @@ Global
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.All_Release|x86.Build.0 = Release|x86
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|x86.ActiveCfg = Debug|x86
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.Debug|x86.Build.0 = Debug|x86
 		{1ED68A9B-6698-4609-B9E6-8E08B6055F2E}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -516,8 +516,8 @@ Global
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.All_Release|x86.Build.0 = Release|x86
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|x86.ActiveCfg = Debug|x86
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.Debug|x86.Build.0 = Debug|x86
 		{E6279FF8-362A-41E6-AC0D-D0861D43F01C}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -546,8 +546,8 @@ Global
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.All_Release|x86.Build.0 = Release|x86
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|x86.ActiveCfg = Debug|x86
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.Debug|x86.Build.0 = Debug|x86
 		{70E29C6B-B926-4859-9548-23375BF1E1B5}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -576,8 +576,8 @@ Global
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.All_Release|x86.Build.0 = Release|x86
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|x86.ActiveCfg = Debug|x86
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.Debug|x86.Build.0 = Debug|x86
 		{D1E4454F-DB09-402D-AD87-1E3BD17266A9}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -606,8 +606,8 @@ Global
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.All_Release|x86.Build.0 = Release|x86
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|x86.ActiveCfg = Debug|x86
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.Debug|x86.Build.0 = Debug|x86
 		{2717DB4C-7E94-4277-A880-FC2571096E74}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -636,8 +636,8 @@ Global
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.All_Release|x86.Build.0 = Release|x86
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|x86.ActiveCfg = Debug|x86
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.Debug|x86.Build.0 = Debug|x86
 		{0A162099-DA92-426A-AB70-36F88F9E5DC1}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -666,8 +666,8 @@ Global
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.All_Release|x86.Build.0 = Release|x86
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|x86.ActiveCfg = Debug|x86
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.Debug|x86.Build.0 = Debug|x86
 		{C0528858-F32D-4C0C-8EC8-CEDB53C01402}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -696,8 +696,8 @@ Global
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.All_Release|x86.Build.0 = Release|x86
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|x86.ActiveCfg = Debug|x86
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.Debug|x86.Build.0 = Debug|x86
 		{F732435A-0188-456C-8F06-7FBA1842FB35}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -726,8 +726,8 @@ Global
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.All_Release|x86.Build.0 = Release|x86
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|x86.ActiveCfg = Debug|x86
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.Debug|x86.Build.0 = Debug|x86
 		{D7B71F40-C941-4364-A25F-8D41B384507A}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -756,8 +756,8 @@ Global
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.All_Release|x86.Build.0 = Release|x86
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|x86.ActiveCfg = Debug|x86
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.Debug|x86.Build.0 = Debug|x86
 		{AED060F0-495C-494C-89C2-7A96A0FA3762}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -786,8 +786,8 @@ Global
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.All_Release|x86.Build.0 = Release|x86
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|x86.ActiveCfg = Debug|x86
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.Debug|x86.Build.0 = Debug|x86
 		{484028B6-3AAE-4F7E-A88A-76BEEB70203B}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -816,8 +816,8 @@ Global
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.All_Release|x86.Build.0 = Release|x86
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|x86.ActiveCfg = Debug|x86
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.Debug|x86.Build.0 = Debug|x86
 		{1F52B5EC-A2F1-4E53-9E1A-4658296C5BB5}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -846,8 +846,8 @@ Global
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.All_Release|x86.Build.0 = Release|Any CPU
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|x86.ActiveCfg = Debug|x86
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.Debug|x86.Build.0 = Debug|x86
 		{32EFB306-DEF8-4488-B1AE-46D5B183C373}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -876,8 +876,8 @@ Global
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.All_Release|x86.Build.0 = Release|Any CPU
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|x86.ActiveCfg = Debug|x86
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.Debug|x86.Build.0 = Debug|x86
 		{4D5AF0A3-1B96-42C8-910D-0C4852EA22F4}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -906,8 +906,8 @@ Global
 		{052692BF-D782-4888-B34D-89D6B1379340}.All_Release|x86.Build.0 = Release|Any CPU
 		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|x86.ActiveCfg = Debug|x86
 		{052692BF-D782-4888-B34D-89D6B1379340}.Debug|x86.Build.0 = Debug|x86
 		{052692BF-D782-4888-B34D-89D6B1379340}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -936,8 +936,8 @@ Global
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.All_Release|x86.Build.0 = Release|Any CPU
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|x86.ActiveCfg = Debug|x86
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.Debug|x86.Build.0 = Debug|x86
 		{4AD7F77E-617C-4741-82AE-E7A41C85EE4D}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -966,8 +966,8 @@ Global
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.All_Release|x86.Build.0 = Release|Any CPU
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|x86.ActiveCfg = Debug|x86
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.Debug|x86.Build.0 = Debug|x86
 		{6733CFE6-C86A-4BD6-817C-292E0638CE4F}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -996,8 +996,8 @@ Global
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.All_Release|x86.Build.0 = Release|Any CPU
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|x86.ActiveCfg = Debug|x86
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.Debug|x86.Build.0 = Debug|x86
 		{8C342A81-387E-403D-9140-17C4A4C4292E}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -1026,8 +1026,8 @@ Global
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.All_Release|x86.Build.0 = Release|Any CPU
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|x86.ActiveCfg = Debug|x86
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.Debug|x86.Build.0 = Debug|x86
 		{48D99DF3-018D-4B3F-BB22-5C7F6F6A7E77}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -1056,8 +1056,8 @@ Global
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.All_Release|x86.Build.0 = Release|Any CPU
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|x86.ActiveCfg = Debug|x86
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.Debug|x86.Build.0 = Debug|x86
 		{4E68F218-5135-4D92-8C17-14FAA5D4CBF3}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -1086,8 +1086,8 @@ Global
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.All_Release|x86.Build.0 = Release|Any CPU
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|x86.ActiveCfg = Debug|x86
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.Debug|x86.Build.0 = Debug|x86
 		{DF1A8F81-CE9B-499E-9258-27F346B32A8B}.NoDevExpress_Debug|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
Already made my changes a few years ago for (older) panasonic TV sets (2020 and earlier) with SVL.BIN format.
Finally had time to reintegrate them to your most recent build - some minor changes overall.